### PR TITLE
Fix: squid:S1185, remove unnecessary method override that simple call…

### DIFF
--- a/RushORM/app/src/androidTest/java/co/uk/rushexample/BugTests.java
+++ b/RushORM/app/src/androidTest/java/co/uk/rushexample/BugTests.java
@@ -35,11 +35,6 @@ public class BugTests extends ApplicationTestCase<Application> {
         Utils.setUp(getContext());
     }
 
-    @Override
-    public void tearDown() throws Exception {
-        super.tearDown();
-    }
-
     public void testBug6() throws Exception {
 
         Bug6 user = new Bug6(null);

--- a/RushORM/app/src/androidTest/java/co/uk/rushexample/ConflictsTests.java
+++ b/RushORM/app/src/androidTest/java/co/uk/rushexample/ConflictsTests.java
@@ -25,11 +25,6 @@ public class ConflictsTests extends ApplicationTestCase<Application> {
         Utils.setUp(getContext());
     }
 
-    @Override
-    public void tearDown() throws Exception {
-        super.tearDown();
-    }
-
     public void testNoConflicts() throws Exception {
         TestObject original = new TestObject();
         original.stringField = "version1";

--- a/RushORM/app/src/androidTest/java/co/uk/rushexample/DeleteTests.java
+++ b/RushORM/app/src/androidTest/java/co/uk/rushexample/DeleteTests.java
@@ -27,11 +27,6 @@ public class DeleteTests extends ApplicationTestCase<Application> {
         Utils.setUp(getContext());
     }
 
-    @Override
-    public void tearDown() throws Exception {
-        super.tearDown();
-    }
-
     public void testDeleteSingle() throws Exception {
 
         TestObject testObject = new TestObject();

--- a/RushORM/app/src/androidTest/java/co/uk/rushexample/FileTests.java
+++ b/RushORM/app/src/androidTest/java/co/uk/rushexample/FileTests.java
@@ -26,11 +26,6 @@ public class FileTests extends ApplicationTestCase<Application> {
         Utils.setUp(getContext());
     }
 
-    @Override
-    public void tearDown() throws Exception {
-        super.tearDown();
-    }
-
     public void testSaveText() throws Exception {
 
         RushTextFile file = new RushTextFile(getContext().getFilesDir().getAbsolutePath());

--- a/RushORM/app/src/androidTest/java/co/uk/rushexample/LikeTests.java
+++ b/RushORM/app/src/androidTest/java/co/uk/rushexample/LikeTests.java
@@ -23,11 +23,6 @@ public class LikeTests extends ApplicationTestCase<Application> {
         Utils.setUp(getContext());
     }
 
-    @Override
-    public void tearDown() throws Exception {
-        super.tearDown();
-    }
-
     public void testLikeString() throws Exception {
         TestObject testObject = new TestObject();
         testObject.stringField = "abcdef";

--- a/RushORM/app/src/androidTest/java/co/uk/rushexample/ModifierTests.java
+++ b/RushORM/app/src/androidTest/java/co/uk/rushexample/ModifierTests.java
@@ -22,11 +22,6 @@ public class ModifierTests extends ApplicationTestCase<Application> {
         Utils.setUp(getContext());
     }
 
-    @Override
-    public void tearDown() throws Exception {
-        super.tearDown();
-    }
-
     public void testPublic() throws Exception {
 
         TestModifiers object = new TestModifiers();

--- a/RushORM/app/src/androidTest/java/co/uk/rushexample/RushListFieldTests.java
+++ b/RushORM/app/src/androidTest/java/co/uk/rushexample/RushListFieldTests.java
@@ -28,11 +28,6 @@ public class RushListFieldTests extends ApplicationTestCase<Application> {
         Utils.setUp(getContext());
     }
 
-    @Override
-    public void tearDown() throws Exception {
-            super.tearDown();
-    }
-
     public void testCount() throws Exception{
 
         List<TestObject> objects = new ArrayList<>();

--- a/RushORM/app/src/androidTest/java/co/uk/rushexample/SaveAndUpdateTest.java
+++ b/RushORM/app/src/androidTest/java/co/uk/rushexample/SaveAndUpdateTest.java
@@ -29,11 +29,6 @@ public class SaveAndUpdateTest extends ApplicationTestCase<Application> {
         Utils.setUp(getContext());
     }
 
-    @Override
-    public void tearDown() throws Exception {
-        super.tearDown();
-    }
-
     public void testSaveString() throws Exception {
 
         TestObject testObject = new TestObject();

--- a/RushORM/app/src/androidTest/java/co/uk/rushexample/SearchTests.java
+++ b/RushORM/app/src/androidTest/java/co/uk/rushexample/SearchTests.java
@@ -27,11 +27,6 @@ public class SearchTests extends ApplicationTestCase<Application> {
         Utils.setUp(getContext());
     }
 
-    @Override
-    public void tearDown() throws Exception {
-        super.tearDown();
-    }
-
     public void testFindByString() throws Exception {
 
         TestObject testObject = new TestObject();

--- a/RushORM/app/src/androidTest/java/co/uk/rushexample/SerializationTests.java
+++ b/RushORM/app/src/androidTest/java/co/uk/rushexample/SerializationTests.java
@@ -32,11 +32,6 @@ public class SerializationTests extends ApplicationTestCase<Application> {
         Utils.setUp(getContext());
     }
 
-    @Override
-    public void tearDown() throws Exception {
-        super.tearDown();
-    }
-
     public void testSerialize() throws Exception {
 
         TestObject testObject = new TestObject();

--- a/RushORM/app/src/androidTest/java/co/uk/rushexample/SpeedTests.java
+++ b/RushORM/app/src/androidTest/java/co/uk/rushexample/SpeedTests.java
@@ -29,11 +29,6 @@ public class SpeedTests extends ApplicationTestCase<Application> {
         Utils.setUp(getContext());
     }
 
-    @Override
-    public void tearDown() throws Exception {
-        super.tearDown();
-    }
-
     public void testSave1000ChildRows() throws Exception {
 
         Date date = new Date();

--- a/RushORM/app/src/androidTest/java/co/uk/rushexample/UpgradeTests.java
+++ b/RushORM/app/src/androidTest/java/co/uk/rushexample/UpgradeTests.java
@@ -57,11 +57,6 @@ public class UpgradeTests extends ApplicationTestCase<Application> {
         getContext().deleteDatabase("rush.db");
     }
 
-    @Override
-    public void tearDown() throws Exception {
-        super.tearDown();
-    }
-
     public void testUpgradeTableNameString() throws Exception {
         List<Class<? extends Rush>> classes = new ArrayList<>();
         classes.add(TestBase1.class);


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
 squid:S1185 - Overriding methods should do more than simply call the same method in the super class
 You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S1185

Please let me know if you have any questions.
Ayman Elkfrawy