### PR TITLE
Multiple code improvements for sonar rules: squid:S1155 and squid:S1118

### DIFF
--- a/RushORM/app/src/androidTest/java/co/uk/rushexample/ConflictsTests.java
+++ b/RushORM/app/src/androidTest/java/co/uk/rushexample/ConflictsTests.java
@@ -40,7 +40,7 @@ public class ConflictsTests extends ApplicationTestCase<Application> {
 
         List<RushConflict> conflicts = loadedOriginal.saveOnlyWithoutConflict();
 
-        assertTrue(conflicts.size() == 0);
+        assertTrue(conflicts.isEmpty());
     }
 
     public void testConflicts() throws Exception {
@@ -85,7 +85,7 @@ public class ConflictsTests extends ApplicationTestCase<Application> {
         conflicts.get(0).resolve();
         
         List<RushConflict> conflicts2 = original.saveOnlyWithoutConflict();
-        assertTrue(conflicts2.size() == 0);
+        assertTrue(conflicts2.isEmpty());
     }
 
     public void testResolveWithBackgroundSaveConflicts() throws Exception {

--- a/RushORM/app/src/androidTest/java/co/uk/rushexample/DeleteTests.java
+++ b/RushORM/app/src/androidTest/java/co/uk/rushexample/DeleteTests.java
@@ -148,7 +148,7 @@ public class DeleteTests extends ApplicationTestCase<Application> {
         RushCore.getInstance().delete(loadedObjects);
 
         List<TestObject> loadedObjects2 = new RushSearch().find(TestObject.class);
-        assertTrue(loadedObjects2.size() == 0);
+        assertTrue(loadedObjects2.isEmpty());
     }
 
     public void testDeleteTable() throws Exception {
@@ -158,7 +158,7 @@ public class DeleteTests extends ApplicationTestCase<Application> {
         RushCore.getInstance().deleteAll(TestObject.class);
 
         List<TestObject> loadedObjects = new RushSearch().find(TestObject.class);
-        assertTrue(loadedObjects.size() == 0);
+        assertTrue(loadedObjects.isEmpty());
     }
 
     public void testDeleteDatabase() throws Exception {
@@ -168,7 +168,7 @@ public class DeleteTests extends ApplicationTestCase<Application> {
         RushCore.getInstance().clearDatabase();
 
         List<TestObject> loadedObjects = new RushSearch().find(TestObject.class);
-        assertTrue(loadedObjects.size() == 0);
+        assertTrue(loadedObjects.isEmpty());
     }
 
 }

--- a/RushORM/app/src/androidTest/java/co/uk/rushexample/SearchTests.java
+++ b/RushORM/app/src/androidTest/java/co/uk/rushexample/SearchTests.java
@@ -180,7 +180,7 @@ public class SearchTests extends ApplicationTestCase<Application> {
                 .whereEqual("intField", 5)
                 .find(TestObject.class);
 
-        assertTrue(results.size() == 0);
+        assertTrue(results.isEmpty());
     }
 
     public void testFindByStringAndIntWrongString() throws Exception {
@@ -195,7 +195,7 @@ public class SearchTests extends ApplicationTestCase<Application> {
                 .whereEqual("intField", 5)
                 .find(TestObject.class);
 
-        assertTrue(results.size() == 0);
+        assertTrue(results.isEmpty());
     }
 
     public void testFindByStringOrIntWrongInt() throws Exception {

--- a/RushORM/app/src/androidTest/java/co/uk/rushexample/SerializationTests.java
+++ b/RushORM/app/src/androidTest/java/co/uk/rushexample/SerializationTests.java
@@ -111,7 +111,7 @@ public class SerializationTests extends ApplicationTestCase<Application> {
         String jsonString = RushCore.getInstance().serialize(objects);
 
         List<Rush> deserializeObject = RushCore.getInstance().deserialize(jsonString);
-        assertTrue(deserializeObject.size() == 0);
+        assertTrue(deserializeObject.isEmpty());
     }
 
     public void testSerializeMix() throws Exception {

--- a/RushORM/app/src/androidTest/java/co/uk/rushexample/Utils.java
+++ b/RushORM/app/src/androidTest/java/co/uk/rushexample/Utils.java
@@ -9,6 +9,9 @@ import co.uk.rushorm.android.RushAndroid;
  * Created by Stuart on 26/02/15.
  */
 public class Utils {
+
+    private Utils() {
+    }
     
     public static void setUp(Context context) throws InterruptedException {
         context.deleteDatabase("rush.db");


### PR DESCRIPTION
This pull request fix the following Sonar rules:
**squid:S1155** - “Collection.isEmpty() should be used to test for emptiness”. 
**squid:S1118** - “Utility classes should not have public constructors ”.

 You can find more information about the issues here: 
 https://dev.eclipse.org/sonar/rules/show/squid:S1155
 https://dev.eclipse.org/sonar/rules/show/squid:S1118

 Please let me know if you have any questions.
Ayman Elkfrawy.