### PR TITLE
Replacement of "compile" with "implementation"

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Make sure your project is using maven central by including this in your gradle f
 Add the dependency in your build file:
 
     dependencies {
-       compile 'co.uk.rushorm:rushandroid:1.3.0’
+       implementation 'co.uk.rushorm:rushandroid:1.3.0’
     }
 
 <hr>


### PR DESCRIPTION
As "compile" is going to be deprecated end-2018, this PR replaces with "implementation" that is the new usage.